### PR TITLE
Add support for RFS-KK* models

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This integration allows to control smart kettles from **Redmond SkyKettle** seri
 * **RK-M1**xx
 * **RK-G2**xx
 * **RK-M2**xx
+* **RFS-KK**xx
 
 ## Features
 * Allows to set target temperature.

--- a/custom_components/skykettle/light.py
+++ b/custom_components/skykettle/light.py
@@ -23,7 +23,7 @@ LIGHT_GAME = "light"
 async def async_setup_entry(hass, entry, async_add_entities, discovery_info=None):
     """Set up the SkyKettle entry."""
     model_code = hass.data[DOMAIN][entry.entry_id][DATA_CONNECTION].model_code
-    if model_code in [1, 2]:
+    if model_code in [1, 2, 3]:
         async_add_entities([
             KettleLight(hass, entry, LIGHT_GAME),
             KettleLight(hass, entry, SkyKettle.LIGHT_BOIL, 0),
@@ -114,7 +114,7 @@ class KettleLight(LightEntity):
 
     @property
     def available(self):
-        if self.kettle.model_code in [1, 2]:
+        if self.kettle.model_code in [1, 2, 3]:
             if self.light_type == LIGHT_GAME:
                 return self.kettle.available
             else:

--- a/custom_components/skykettle/number.py
+++ b/custom_components/skykettle/number.py
@@ -23,7 +23,7 @@ NUMBER_LAMP_AUTO_OFF_HOURS = "lamp_auto_off_hours"
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the SkyKettle entry."""
     model_code = hass.data[DOMAIN][entry.entry_id][DATA_CONNECTION].model_code
-    if model_code in [1, 2]:
+    if model_code in [1, 2, 3]:
         async_add_entities([
             SkyNumber(hass, entry, NUMBER_TYPE_BOIL_TIME),
             SkyNumber(hass, entry, NUMBER_TEMPERATURE_LOW),

--- a/custom_components/skykettle/sensor.py
+++ b/custom_components/skykettle/sensor.py
@@ -22,7 +22,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities([
         SkySensor(hass, entry, SENSOR_TYPE_SUCCESS_RATE),
     ])
-    if model_code in [1, 2]:
+    if model_code in [1, 2, 3]:
         async_add_entities([
             SkySensor(hass, entry, SENSOR_TYPE_WATER_FRESHNESS),
         ])

--- a/custom_components/skykettle/switch.py
+++ b/custom_components/skykettle/switch.py
@@ -24,7 +24,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities([
         SkySwitch(hass, entry, SWITCH_MAIN)
     ])
-    if model_code in [1, 2]:
+    if model_code in [1, 2, 3]:
         async_add_entities([
             SkySwitch(hass, entry, SWITCH_SOUND),
             SkySwitch(hass, entry, SWITCH_LIGHT_SYNC),

--- a/custom_components/skykettle/water_heater.py
+++ b/custom_components/skykettle/water_heater.py
@@ -93,7 +93,7 @@ class SkyWaterHeater(WaterHeaterEntity):
 
     @property
     def operation_list(self):
-        if self.kettle.model_code in [1, 2]:
+        if self.kettle.model_code in [1, 2, 3]:
             return [
                 STATE_OFF,
                 SkyKettle.MODE_NAMES[SkyKettle.MODE_HEAT],


### PR DESCRIPTION
After v1.5 release integration accidentialy dropped support for
RFS-KKL00 kettle which worked perfectly on v1.4 version.
<details>
  <summary>Device page on v1.4</summary>

![](https://puu.sh/Jc0F8/9d2900d11d.png)

</details>

<details>
  <summary>Errors on v1.5</summary>

### Error setting up entry RFS-KKL00 (ED:99:2C:79:90:A3) for skykettle

```python
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 353, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/config/custom_components/skykettle/__init__.py", line 32, in async_setup_entry
    kettle = KettleConnection(
  File "/config/custom_components/skykettle/kettle_connection.py", line 26, in __init__
    super().__init__(model)
  File "/config/custom_components/skykettle/skykettle.py", line 85, in __init__
    raise SkyKettleError("Unknown kettle model")
custom_components.skykettle.skykettle.SkyKettleError: Unknown kettle model
```

</details>