### PR TITLE
Fixed TimeoutError excess

### DIFF
--- a/custom_components/skykettle/kettle_connection.py
+++ b/custom_components/skykettle/kettle_connection.py
@@ -60,9 +60,9 @@ class KettleConnection(SkyKettle):
         _LOGGER.debug(f"Writing command {command:02x}, data: [{' '.join([f'{c:02x}' for c in params])}]")
         data = bytes([0x55, self._iter, command] + list(params) + [0xAA])
         # _LOGGER.debug(f"Writing {data}")
+        self._last_data = None
         await self._client.write_gatt_char(KettleConnection.UUID_TX, data)
         timeout_time = monotonic() + KettleConnection.BLE_RECV_TIMEOUT
-        self._last_data = None
         while True:
             await asyncio.sleep(0.05)
             if self._last_data:


### PR DESCRIPTION
Hi! After HAOS 2023.09 the performance of the addon was greatly degraded due to lots of timeouts and disconnects. I found out that in `kettle_connection.py` in `command` there is a section where the command is sent and the last package received is set to `None`. After that there is a loop awaiting for a new package to be received. However, the loop often fails with timeouts.

I discovered that the awaited package is actually received and handled by `_rx_callback` successfully. The thing is that it is received and written earlier than the `_last_data` is set to `None`, so the package is practically lost and not handled by the loop in `command`. 

Resetting `_last_data` before sending data to the kettle seems to do the trick. Currently running HAOS 2024.1.2. The rate of timeouts has practically gone to zero, the connection is stable, no new exceptions noticed. 

This also seems to partially fix #49, regarding connection stability. #33 seems to fix another half of #49 with Bluetooth proxies. In my case, adding `await` allowed to use my proxy again.