### PR TITLE
Removed usage of deprecated constants

### DIFF
--- a/custom_components/skykettle/__init__.py
+++ b/custom_components/skykettle/__init__.py
@@ -1,15 +1,18 @@
 """Support for SkyKettle."""
 import logging
-from .const import *
-from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import *
+from datetime import timedelta
+
 import homeassistant.helpers.event as ev
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (ATTR_SW_VERSION, CONF_DEVICE,
+                                 CONF_FRIENDLY_NAME, CONF_MAC, CONF_PASSWORD,
+                                 CONF_SCAN_INTERVAL, Platform)
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import DeviceInfo
-from datetime import timedelta
+
+from .const import *
 from .kettle_connection import KettleConnection
-from .skykettle import SkyKettle
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/skykettle/config_flow.py
+++ b/custom_components/skykettle/config_flow.py
@@ -1,17 +1,18 @@
 """Config flow for Sky Kettle integration."""
+
 import logging
-import re
 import secrets
 import traceback
-import sys
-import asyncio
-import subprocess
+
 import voluptuous as vol
-from homeassistant.components import bluetooth
-from homeassistant.const import *
-from homeassistant import config_entries
-from homeassistant.core import callback
+
 import homeassistant.helpers.config_validation as cv
+from homeassistant import config_entries
+from homeassistant.components import bluetooth
+from homeassistant.const import (CONF_DEVICE, CONF_FRIENDLY_NAME, CONF_MAC,
+                                 CONF_PASSWORD, CONF_SCAN_INTERVAL)
+from homeassistant.core import callback
+
 from .const import *
 from .kettle_connection import KettleConnection
 from .skykettle import SkyKettle

--- a/custom_components/skykettle/kettle_connection.py
+++ b/custom_components/skykettle/kettle_connection.py
@@ -1,11 +1,14 @@
-import logging
 import asyncio
+import logging
+import traceback
 from time import monotonic
+
+from bleak import BleakClient
+
 from homeassistant.components import bluetooth
-from bleak import BleakScanner, BleakClient
+
 from .const import *
 from .skykettle import SkyKettle
-import traceback
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/skykettle/light.py
+++ b/custom_components/skykettle/light.py
@@ -1,18 +1,15 @@
 """SkyKettle."""
 import logging
 
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    ATTR_RGB_COLOR,
-    COLOR_MODE_RGB,
-    LightEntity,
-)
+from homeassistant.components.light import (ATTR_BRIGHTNESS, ATTR_RGB_COLOR,
+                                            ColorMode, LightEntity, LightEntityFeature)
+from homeassistant.const import CONF_FRIENDLY_NAME, STATE_OFF
+from homeassistant.helpers.dispatcher import (async_dispatcher_connect,
+                                              async_dispatcher_send)
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.dispatcher import async_dispatcher_send, async_dispatcher_connect
-from homeassistant.const import *
 
-from .skykettle import SkyKettle
 from .const import *
+from .skykettle import SkyKettle
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -155,17 +152,17 @@ class KettleLight(LightEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return 0
+        return LightEntityFeature(0)
 
     @property
     def color_mode(self):
         """Return the color mode of the light."""
-        return COLOR_MODE_RGB
+        return ColorMode.RGB
 
     @property
     def supported_color_modes(self):
         """Flag supported color modes."""
-        return {COLOR_MODE_RGB}
+        return {ColorMode.RGB}
 
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""

--- a/custom_components/skykettle/number.py
+++ b/custom_components/skykettle/number.py
@@ -1,13 +1,15 @@
 """SkyKettle."""
 import logging
 
-from homeassistant.components.number import NumberMode, NumberEntity
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.const import (CONF_FRIENDLY_NAME, UnitOfTemperature,
+                                 UnitOfTime)
+from homeassistant.helpers.dispatcher import (async_dispatcher_connect,
+                                              async_dispatcher_send)
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.dispatcher import async_dispatcher_send, async_dispatcher_connect
-from homeassistant.const import *
 
-from .skykettle import SkyKettle
 from .const import *
+from .skykettle import SkyKettle
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -142,15 +144,15 @@ class SkyNumber(NumberEntity):
         if self.number_type == NUMBER_TYPE_BOIL_TIME:
             return None
         if self.number_type == NUMBER_TEMPERATURE_LOW:
-            return "°C"
+            return UnitOfTemperature.CELSIUS
         if self.number_type == NUMBER_TEMPERATURE_MID:
-            return "°C"
+            return UnitOfTemperature.CELSIUS
         if self.number_type == NUMBER_TEMPERATURE_HIGH:
-            return "°C"
+            return UnitOfTemperature.CELSIUS
         if self.number_type == NUMBER_COLOR_INTERVAL:
             return "secs"
         if self.number_type == NUMBER_LAMP_AUTO_OFF_HOURS:
-            return "h"
+            return UnitOfTime.HOURS
 
     @property
     def native_value(self):

--- a/custom_components/skykettle/sensor.py
+++ b/custom_components/skykettle/sensor.py
@@ -1,13 +1,15 @@
 """SkyKettle."""
 import logging
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass, SensorDeviceClass
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
+                                             SensorStateClass)
+from homeassistant.const import (CONF_FRIENDLY_NAME, PERCENTAGE, UnitOfEnergy,
+                                 UnitOfTime)
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.const import *
+from homeassistant.helpers.entity import EntityCategory
 
-from .skykettle import SkyKettle
 from .const import *
+from .skykettle import SkyKettle
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -154,11 +156,11 @@ class SkySensor(SensorEntity):
     @property
     def native_unit_of_measurement(self):
         if self.sensor_type == SENSOR_TYPE_ENERGY:
-            return ENERGY_WATT_HOUR
+            return UnitOfEnergy.WATT_HOUR
         if self.sensor_type == SENSOR_TYPE_ONTIME:
-            return TIME_SECONDS
+            return UnitOfTime.SECONDS
         if self.sensor_type == SENSOR_TYPE_WATER_FRESHNESS:
-            return TIME_HOURS
+            return UnitOfTime.HOURS
         if self.sensor_type == SENSOR_TYPE_SUCCESS_RATE:
             return PERCENTAGE
         return None

--- a/custom_components/skykettle/skykettle.py
+++ b/custom_components/skykettle/skykettle.py
@@ -1,10 +1,10 @@
-import logging
-from struct import pack, unpack
-from collections import namedtuple
-import time
-from datetime import datetime, timedelta
 import calendar
+import logging
+import time
 from abc import abstractmethod
+from collections import namedtuple
+from datetime import datetime, timedelta
+from struct import pack, unpack
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/skykettle/switch.py
+++ b/custom_components/skykettle/switch.py
@@ -2,12 +2,13 @@
 import logging
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.const import CONF_FRIENDLY_NAME
+from homeassistant.helpers.dispatcher import (async_dispatcher_connect,
+                                              async_dispatcher_send)
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.dispatcher import async_dispatcher_send, async_dispatcher_connect
-from homeassistant.const import *
 
-from .skykettle import SkyKettle
 from .const import *
+from .skykettle import SkyKettle
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/skykettle/water_heater.py
+++ b/custom_components/skykettle/water_heater.py
@@ -1,15 +1,16 @@
 """SkyKettle."""
 import logging
-from homeassistant.components.water_heater import (
-    SUPPORT_OPERATION_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
-    WaterHeaterEntity,
-)
-from homeassistant.helpers.dispatcher import async_dispatcher_send, async_dispatcher_connect
-from homeassistant.const import *
 
-from .skykettle import SkyKettle
+from homeassistant.components.water_heater import (WaterHeaterEntity,
+                                                   WaterHeaterEntityFeature)
+from homeassistant.const import (ATTR_SW_VERSION, ATTR_TEMPERATURE,
+                                 CONF_FRIENDLY_NAME, CONF_SCAN_INTERVAL,
+                                 STATE_OFF, UnitOfTemperature)
+from homeassistant.helpers.dispatcher import (async_dispatcher_connect,
+                                              async_dispatcher_send)
+
 from .const import *
+from .skykettle import SkyKettle
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,11 +78,11 @@ class SkyWaterHeater(WaterHeaterEntity):
 
     @property
     def supported_features(self):
-        return SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
+        return WaterHeaterEntityFeature.TARGET_TEMPERATURE | WaterHeaterEntityFeature.OPERATION_MODE
 
     @property
     def temperature_unit(self):
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def min_temp(self):


### PR DESCRIPTION
- migrated from deprecated constants, which will be removed in `HA 2025.1`, to `EntityFeature` enums (#54 #59);
- optimized imports, since wildcard imports food log with deprecation warnings;
- changed `KettleLight.supported_features` to return `LightEntityFeature(0)` insted of just `0` as expected by HA

All changes was successfully tested on `SkyKettle RK-G203S`