### PR TITLE
Set operation mode with temperature

### DIFF
--- a/custom_components/skykettle/kettle_connection.py
+++ b/custom_components/skykettle/kettle_connection.py
@@ -336,11 +336,13 @@ class KettleConnection(SkyKettle):
     def target_mode_str(self):
         return self.get_mode_name(self.target_mode)
 
-    async def set_target_temp(self, target_temp):
+    async def set_target_temp(self, target_temp, operation_mode = None):
         """Set new temperature."""
         if target_temp == self.target_temp: return # already set
         _LOGGER.info(f"Setting target temperature to {target_temp}")
         target_mode = self.target_mode
+        vs = [k for k, v in SkyKettle.MODE_NAMES.items() if v == operation_mode]
+        if len(vs) > 0: target_mode = vs[0]
         # Some checks for mode
         if target_temp < SkyKettle.MIN_TEMP:
             # Just turn off

--- a/custom_components/skykettle/water_heater.py
+++ b/custom_components/skykettle/water_heater.py
@@ -2,7 +2,8 @@
 import logging
 
 from homeassistant.components.water_heater import (WaterHeaterEntity,
-                                                   WaterHeaterEntityFeature)
+                                                   WaterHeaterEntityFeature,
+                                                   ATTR_OPERATION_MODE)
 from homeassistant.const import (ATTR_SW_VERSION, ATTR_TEMPERATURE,
                                  CONF_FRIENDLY_NAME, CONF_SCAN_INTERVAL,
                                  STATE_OFF, UnitOfTemperature)
@@ -174,7 +175,8 @@ class SkyWaterHeater(WaterHeaterEntity):
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""
         target_temperature = kwargs.get(ATTR_TEMPERATURE)
-        await self.kettle.set_target_temp(target_temperature)
+        operation_mode = kwargs.get(ATTR_OPERATION_MODE)
+        await self.kettle.set_target_temp(target_temperature, operation_mode)
         self.hass.async_add_executor_job(dispatcher_send, self.hass, DISPATCHER_UPDATE)
 
     async def async_set_operation_mode(self, operation_mode):


### PR DESCRIPTION
Hi! `water_heater.set_temperature` service supports setting operation mode when setting temperature, but the integration does not support the feature, although there are some functions in the code for the feature to work. I've tested it with RK-G211S and it works without issues. Are there any limitations with other models? If not, here are some fixes to support setting operation mode together with temperature. I find it much easier to use then setting temperature and operation mode separately with two calls :-)

Приветствую! Сервис `water_heater.set_temperature` поддерживает установку режима работы одновременно с температурой, однако в данной интеграции так сделать нельзя, хоть и некоторые функции написаны с поддержкой этой особенности. Я протестировал на RK-G211S, всё работает без проблем. Есть ли какие-либо ограничения на других моделях? Если нет, то предлагаю внести правки чтобы поддерживать установку режима и температуры одновременно. Кажется, это намного проще и удобнее, чем ставить температуру и режим отдельно двумя вызовами :-)